### PR TITLE
Correct paragraph direction detection.

### DIFF
--- a/biditext.py
+++ b/biditext.py
@@ -19,7 +19,7 @@
 # This script uses fribidi library to display rtl text properly
 
 import weechat
-from pyfribidi import log2vis, LTR
+from pyfribidi import log2vis, ON
 
 SCRIPT_NAME    = "biditext"
 SCRIPT_AUTHOR  = "Oscar Morante <oscar@morante.eu>"
@@ -29,7 +29,13 @@ SCRIPT_DESC    = "Use fribidi to handle RTL text"
 
 
 def biditext_cb(data, modifier, modifier_data, line):
-    return log2vis(line, LTR)
+    # We assume a tab separates the nick from the text
+    text = line.split('\t', 1)
+    if len(text) > 1:
+        text[1] = log2vis(text[1], ON)
+        return '\t'.join(text)
+
+    return line
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The paragraph direction is an important part of the BiDi algorithm.
Before this patch, the paragraph direction was hard-coded to LTR which
meant some text was not presented correctly.

This patch fixes that by attempting to find the separator between the
nick and the message (it assumes it's a tab, I don't know if this can be
anything else) and then only reorders the message, while letting it
automatically detect the paragraph direction for it.

BiDi text now shows correctly.
An example text to illustrate the issue:
A (1)
(A being a bidi character)
would be printed as:
1) A)
Instead of:
(1) A
